### PR TITLE
Fix Enable to Enabled trouble

### DIFF
--- a/Enable to Enabled trouble
+++ b/Enable to Enabled trouble
@@ -1,0 +1,11 @@
+
+Enable to Enabled trouble
+
+I can't get the hotkey to "unenabe"  What do I do to fix this as the Instapaper keeps loadin uninvited?
+Enab
+    
+    • Hotkeys • Misc
+    Any changes made here will not take effect on opened pages until they are reloaded.
+    Enabled
+    Enable Hotkeys
+    Enabling hotkeys may create a prompt asking for additional permissions.


### PR DESCRIPTION
Enable to Enabled trouble

I can't get the hotkey to "unenabe"  What do I do to fix this as the Instapaper keeps loadin uninvited?
Enab

```
• Hotkeys • Misc
Any changes made here will not take effect on opened pages until they are reloaded.
Enabled
Enable Hotkeys
Enabling hotkeys may create a prompt asking for additional permissions.
```
